### PR TITLE
chore: migrate to speakeasy workflows 

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,30 +1,25 @@
 name: Generate
 permissions:
-  checks: write
-  contents: write
-  statuses: write
+    checks: write
+    contents: write
+    statuses: write
 "on":
-  workflow_dispatch:
-    inputs:
-      force:
-        description: Force generation of SDKs
-        type: boolean
-        default: false
-  schedule:
-    - cron: 0 0 * * *
+    workflow_dispatch:
+        inputs:
+            force:
+                description: Force generation of SDKs
+                type: boolean
+                default: false
+    schedule:
+        - cron: 0 0 * * *
 jobs:
-  generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
-    with:
-      force: ${{ github.event.inputs.force }}
-      languages: |
-        - python
-      mode: direct
-      openapi_docs: |
-        - https://api-docs-nine-delta.vercel.app/cloud/openapi.json
-      publish_python: true
-      speakeasy_version: latest
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      pypi_token: ${{ secrets.PYPI_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    generate:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        with:
+            force: ${{ github.event.inputs.force }}
+            mode: direct
+            speakeasy_version: latest
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            pypi_token: ${{ secrets.PYPI_TOKEN }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,12 @@
+workflowVersion: 1.0.0
+sources:
+    my-source:
+        inputs:
+            - location: https://api-docs-nine-delta.vercel.app/cloud/openapi.json
+targets:
+    leonardo-python-sdk:
+        target: python
+        source: my-source
+        publish:
+            pypi:
+                token: $PYPI_TOKEN


### PR DESCRIPTION
This PR migrates this SDK to Speakeasy's new workflow file specification https://www.speakeasyapi.dev/docs/workflow-migration. `speakeasy migrate` was run to create this PR.

![CleanShot 2024-04-15 at 12 07 39@2x](https://github.com/Leonardo-Interactive/leonardo-python-sdk/assets/68016351/ef83ac3e-a271-4b98-9cdd-f09b40d892ec)

Benefits:

- Complete generation workflow is emulated locally now by checking out repo and running `speakeasy run`
- Opens up integrations with doc providers.